### PR TITLE
Fix executable path when testing if ormolu is installed

### DIFF
--- a/src/extension.ts
+++ b/src/extension.ts
@@ -16,7 +16,7 @@ export function activate(context: vscode.ExtensionContext) {
       };
 
       try {
-        proc.execSync('ormolu --help');
+        proc.execSync(cfg.executablePath + ' --help');
       } catch (e) {
         return showErrorMessage("Ormolu is not installed", e);
       }

--- a/src/extension.ts
+++ b/src/extension.ts
@@ -15,13 +15,13 @@ export function activate(context: vscode.ExtensionContext) {
         return [];
       };
 
+      const cfg = vscode.workspace.getConfiguration("ormolu");
+
       try {
-        proc.execSync('ormolu --help');
+        proc.execSync(cfg.executablePath + ' --help');
       } catch (e) {
         return showErrorMessage("Ormolu is not installed", e);
       }
-
-      const cfg = vscode.workspace.getConfiguration("ormolu");
 
       let command = cfg.executablePath;
 


### PR DESCRIPTION
The extension fails to format code when specifying an executable path which is no in the PATH variable.
It should use the specified path from the configuration.